### PR TITLE
Additional OSS information

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -2,7 +2,7 @@ fileignoreconfig:
 - filename: .github/workflows/pipeline.yml
   checksum: 3d9f84b548b0d134ec60651cc467582608bcfd70d3ce165b79708b8482167822
 - filename: README.md
-  checksum: 6046fa7667f7ef45032b182d76c70b58d09be680d05ec77e5b0c27709015228d
+  checksum: 76938242e488f89494b342cf2bf5625d7e5310e6086b63c76c7b13837232c7de
 - filename: public/fonts/BundesSerifWeb-Italic.woff
   checksum: 2cad03dd85939c73e892cce6d994a89046677e94ceb11dd1cde5a23a3b35c392
 - filename: public/fonts/BundesSansWeb-BoldItalic.woff

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[github-community@digitalservice.bund.de](mailto:github-community@digitalservice.bund.de). Reports related
+to the community leaders can be sent together with information about the involved
+community leaders to [hallo@digitalservice.bund.de](mailto:hallo@digitalservice.bund.de).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available
+at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CODE_OF_CONDUCT_DE.md
+++ b/CODE_OF_CONDUCT_DE.md
@@ -1,0 +1,135 @@
+# Vereinbarung über Verhaltenskodex für Mitwirkende
+
+## Unsere Verpflichtung
+
+Wir als Mitglieder, Teilnehmende und Verantwortliche unserer Gemeinschaft
+verpflichten uns, allen Teilnehmenden an dem Projekt und unserer Gemeinschaft
+eine belästigungsfreie Beteiligung, unabhängig von Alter, Körpergröße,
+Behinderung, ethnischer Zuordnung, Geschlechtermerkmalen, -identität und -ausdruck,
+Grad der Erfahrung, Bildung, sozialem Status, Nationalität, persönlicher
+Erscheinung, Rasse, Religion oder sexueller Identität und Orientierung
+zu ermöglichen.
+
+Wir verpflichten uns, in einer Weise zu handeln und zu interagieren, die zu
+einer offenen, einladenden, vielfältigen, inklusiven und gesunden Gemeinschaft
+beiträgt.
+
+## Unsere Standards
+
+Beispiele für Verhaltensweisen, die zu einem positiven Umfeld für unsere
+Gemeinschaft beitragen, sind:
+
+- Einfühlungsvermögen und Freundlichkeit gegenüber anderen Menschen zeigen
+- Unterschiedliche Meinungen, Standpunkte und Erfahrungen respektieren
+- Konstruktives Feedback geben und würdevoll annehmen
+- Verantwortung übernehmen und uns bei denjenigen entschuldigen, die von unseren
+  Fehlern betroffen sind, und aus den Erfahrungen lernen
+- Konzentration auf das, was nicht nur für uns als Individuen, sondern für die
+  gesamte Gemeinschaft das Beste ist
+
+Beispiele für inakzeptables Verhalten sind:
+
+- Die Verwendung sexualisierter Sprache, Bilder oder Symbolik sowie unerwünschte
+  Versuche sexueller Annäherung
+- Beleidigende oder abwertende Kommentare, persönliche oder politische Angriffe
+  und Trollen
+- Öffentliche oder private Belästigungen
+- Das Veröffentlichen von privaten Informationen Anderer, wie zum Beispiel
+  physische oder elektronische Adressen, ohne deren ausdrückliche Erlaubnis
+- Anderes Verhalten, welches in einem professionellen Umfeld begründet als
+  unangemessen betrachtet werden kann
+
+## Verantwortlichkeiten bei der Durchsetzung
+
+Die Gemeinschaftsleitung ist verantwortlich dafür, unsere Standards für ein
+akzeptables Verhalten klarzustellen und wird angemessen und fair
+korrigierende Maßnahmen ergreifen um auf jegliches Verhalten, das sie für
+unangemessen, bedrohlich oder beleidigend hält, zu reagieren.
+
+Die Gemeinschaftsleitung hat das Recht und die Verantwortung, Kommentare,
+Commits, Code, Wiki-Bearbeitungen, Support-Tickets und andere Beiträge, die
+nicht mit diesem Verhaltenskodex vereinbar sind, zu entfernen, zu bearbeiten
+oder abzulehnen, und wird die Gründe für eine Mäßigung mitteilen, wenn es
+angebracht ist.
+
+## Geltungsbereich
+
+Dieser Verhaltenskodex gilt für alle Gemeinschaftsbereiche und gilt auch, wenn
+eine Einzelperson die Gemeinschaft offiziell in öffentlichen Bereichen vertritt.
+Beispiele für die Repräsentation unserer Gemeinschaft sind die Verwendung einer
+offiziellen E-Mail-Adresse, das Posten über ein offizielles Social-Media-Konto
+oder das Auftreten als ernannte Vertretung bei einer Online- oder
+Offline-Veranstaltung.
+
+## Durchsetzung
+
+Fälle von missbräuchlichem, belästigendem oder anderweitig inakzeptablem Verhalten
+können unter [github-community@digitalservice.bund.de](mailto:github-community@digitalservice.bund.de)
+der für die Durchsetzung zuständigen Gemeinschaftsleitung gemeldet werden. Fälle
+im Zusammenhang mit Mitgliedern der Gemeinschaftsleitung können zusammen mit einem
+Hinweis auf die beteiligten Mitglieder an [hallo@digitalservice.bund.de](mailto:hallo@digitalservice.bund.de)
+gesendet werden und werden dann separat bearbeitet. Alle Beschwerden werden
+zeitnah und fair geprüft und ermittelt.
+
+Die gesamte Gemeinschaftsleitung ist verpflichtet, die Privatsphäre und die
+Sicherheit derjenigen, die einen Vorfall gemeldet haben, zu respektieren.
+
+## Durchsetzungsrichtlinien
+
+Die Gemeinschaftsleitung wird sich bei der Bestimmung der Konsequenzen für
+jede Handlung, die ihrer Ansicht nach gegen diesen Verhaltenskodex verstößt, an
+diese Richtlinien über die Auswirkungen in der Gemeinschaft halten:
+
+### 1. Berichtigung
+
+**Auswirkungen in der Gemeinschaft**: Verwendung unangemessener Sprache oder
+anderes Verhalten, das in der Gemeinschaft als unprofessionell oder unwillkommen
+gilt.
+
+**Folge**: Eine private, schriftliche Verwarnung der Gemeinschaftsleitung,
+die Klarheit über die Art des Verstoßes und eine Erklärung dafür bietet, warum
+das Verhalten unangemessen war. Eine öffentliche Entschuldigung kann verlangt
+werden.
+
+### 2. Verwarnung
+
+**Auswirkungen in der Gemeinschaft**: Eine Verletzung durch einen einzelnen
+Vorfall oder eine Reihe von Handlungen.
+
+**Folge**: Eine Warnung mit Konsequenzen bei wiederholtem Fehlverhalten. Keine
+Interaktion mit den beteiligten Personen, einschließlich unaufgeforderter
+Interaktion mit denjenigen, die den Verhaltenskodex durchsetzen, für einen
+bestimmten Zeitraum. Dazu gehört die Vermeidung von Interaktionen in
+Gemeinschaftsräumen sowie in externen Kanälen wie sozialen Medien. Ein Verstoß
+gegen diese Bedingungen kann zu einem vorübergehenden oder dauerhaften Verbot
+führen.
+
+### 3. Vorübergehender Ausschluss
+
+**Auswirkungen in der Gemeinschaft**: Eine schwerwiegende Verletzung von
+Gemeinschaftsstandards, einschließlich anhaltend unangemessenen Verhaltens.
+
+**Folge**: Ein zeitlich begrenztes Verbot jeglicher Art von Interaktion oder
+öffentlicher Kommunikation mit der Gemeinschaft. Während dieses Zeitraums ist
+keine öffentliche oder private Interaktion mit den beteiligten Personen erlaubt.
+Auch keine unaufgeforderte Interaktion mit denjenigen, die den Verhaltenskodex
+durchsetzen. Ein Verstoß gegen diese Bedingungen kann zu einem dauerhaften
+Verbot führen.
+
+### 4. Dauerhafter Ausschluss
+
+**Auswirkungen in der Gemeinschaft**: Aufzeigen eines Musters von Verletzungen
+der Gemeinschaftsstandards, einschließlich anhaltend unangemessenen Verhaltens,
+Belästigung einer Person oder Aggression gegen oder Herabsetzung von Gruppen von
+Personen.
+
+**Folge**: Ein dauerhaftes Verbot jeglicher Art von öffentlicher Interaktion
+innerhalb der Gemeinschaft.
+
+## Bezug
+
+Dieser Verhaltenskodex basiert auf dem [Contributor Covenant][homepage],
+Version 2.0, verfügbar unter
+<https://www.contributor-covenant.org/de/version/2/0/code-of-conduct>
+
+[homepage]: https://www.contributor-covenant.org

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 DigitalService GmbH des Bundes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ brew install adr-tools
 ## Contributing
 
 🇬🇧
-Everyone is welcome to contribute the development of the _<please_exchange_with_project_name>_. You can contribute by opening pull request,
+Everyone is welcome to contribute the development of the _remix-application-template_. You can contribute by opening pull request,
 providing documentation or answering questions or giving feedback. Please always follow the guidelines and our
 [Code of Conduct](CODE_OF_CONDUCT.md).
 
 🇩🇪  
-Jede:r ist herzlich eingeladen, die Entwicklung der _<please_exchange_with_project_name>_ mitzugestalten. Du kannst einen Beitrag leisten,
+Jede:r ist herzlich eingeladen, die Entwicklung der _remix-application-template_ mitzugestalten. Du kannst einen Beitrag leisten,
 indem du Pull-Requests eröffnest, die Dokumentation erweiterst, Fragen beantwortest oder Feedback gibst.
 Bitte befolge immer die Richtlinien und unseren [Verhaltenskodex](CODE_OF_CONDUCT_DE.md).
 

--- a/README.md
+++ b/README.md
@@ -114,3 +114,32 @@ For adding new records the [adr-tools](https://github.com/npryce/adr-tools) comm
 ```bash
 brew install adr-tools
 ```
+
+## Contributing
+
+🇬🇧
+Everyone is welcome to contribute the development of the _<please_exchange_with_project_name>_. You can contribute by opening pull request,
+providing documentation or answering questions or giving feedback. Please always follow the guidelines and our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+🇩🇪  
+Jede:r ist herzlich eingeladen, die Entwicklung der _<please_exchange_with_project_name>_ mitzugestalten. Du kannst einen Beitrag leisten,
+indem du Pull-Requests eröffnest, die Dokumentation erweiterst, Fragen beantwortest oder Feedback gibst.
+Bitte befolge immer die Richtlinien und unseren [Verhaltenskodex](CODE_OF_CONDUCT_DE.md).
+
+## Contributing code
+
+🇬🇧
+Open a pull request with your changes and it will be reviewed by someone from the team. When you submit a pull request,
+you declare that you have the right to license your contribution to the DigitalService and the community.
+By submitting the patch, you agree that your contributions are licensed under the MIT license.
+
+Please make sure that your changes have been tested befor submitting a pull request.
+
+🇩🇪  
+Nach dem Erstellen eines Pull Requests wird dieser von einer Person aus dem Team überprüft. Wenn du einen Pull-Request
+einreichst, erklärst du dich damit einverstanden, deinen Beitrag an den DigitalService und die Community zu
+lizenzieren. Durch das Einreichen des Patches erklärst du dich damit einverstanden, dass deine Beiträge unter der
+MIT-Lizenz lizenziert sind.
+
+Bitte stelle sicher, dass deine Änderungen getestet wurden, bevor du einen Pull-Request sendest.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Vulnerabilities
+
+Our team is trying to make sure that our code is secure. Nevertheless, we are very grateful for anyone who finds a security vulnerability and reports it to us.
+
+Please do not report security vulnerabilities through Github directly. Because Github issues are public, this could result in directly disclosing the vulnerability.
+
+Please send any request regarding a potential security vulnerability with all the information that could help to [security@digitalservice.bund.de](mailto:security@digitalservice.bund.de). You can use our [public key ](https://raw.githubusercontent.com/digitalservicebund/public-keys/main/pgp-public-key-security-mail.pem)to encrypt your mail.
+If possible please note the release version or the commit id of the main branch that you have investigated.


### PR DESCRIPTION
We were discussing whether we should include information from [the open source template](https://github.com/digitalservicebund/opensource-template/tree/main) in our other templates at what information.

So far, we include the code of conduct [in the typescript template](https://github.com/digitalservicebund/typescript-vite-application-template) and the security policy in [the java template](https://github.com/digitalservicebund/java-application-template). Both have no contribution section in the readme.

From the discussions I had so far, I see the following points:
- We miss a lot of the information from the open source template in our repositories (e.g. contribution section, code of conduct). Having this in our templates could help us to spread information about it across our projects.
- The templates are also open source and should include information like the security policy & the CoC, too.
- This increases the maintenance overhead. The project templates and the open source template would not be separate and teams can combine them when starting a new project. We would need to maintain the files in the open source template and the projects templates.

Still, as all templates are open source I would propose the following:
- The open source template is the single source of truth and the point to add updates etc..
- The project templates include the information from the open source template as a normal project would. This means they do not give guidance on those files.

This PR should include the necessary changes.

What do you think?

**TLDR:** What files from the open source template should we include in the project templates?