### PR TITLE
chore: Internal GitHub Action migration

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -82,11 +82,6 @@ jobs:
         run: |
           docker build -t ${{ env.IMAGE_NAME }}:${{ github.sha }} . --build-arg COMMIT_SHA=${{ github.sha }}
 
-      - name: Create SBOM
-        uses: digitalservicebund/create-sbom@095884614dac5ea922dfcb09cce2e22f3d6391a3 # v1.1.0
-        with:
-          image_name: ${{ env.IMAGE_NAME }}:${{ github.sha }}
-
       - name: Send failure to Slack
         uses: digitalservicebund/notify-on-failure-gha@15dd05b628141b7bac0ad26e08c1935cb3ba6bc8 # v1.4.0
         if: ${{ failure() }}
@@ -135,7 +130,7 @@ jobs:
       security-events: write
     steps:
       - name: validate github workflow files to have pinned versions
-        uses: digitalservicebund/github-actions-linter@16aee7d3ea804d707e9faf6ab3f049ef560dded7 # v0.1.11
+        uses: digitalservicebund/github-actions-linter@dccac3ada437947aada4bc901daff08ceb87c3f1 # v0.1.11
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # v0.18.0
@@ -212,6 +207,11 @@ jobs:
           docker tag ${{ env.IMAGE_NAME }}:${{ github.sha }} ghcr.io/${{ env.IMAGE_NAME }}
           docker tag ${{ env.IMAGE_NAME }}:${{ github.sha }} ghcr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}
           docker push --all-tags ghcr.io/${{ env.IMAGE_NAME }}
+
+      - name: Create SBOM
+        uses: digitalservicebund/create-sbom@095884614dac5ea922dfcb09cce2e22f3d6391a3 # v1.1.0
+        with:
+          image_name: ${{ env.IMAGE_NAME }}:${{ github.sha }}
 
       - name: Sign the published Docker image
         env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -83,7 +83,7 @@ jobs:
           docker build -t ${{ env.IMAGE_NAME }}:${{ github.sha }} . --build-arg COMMIT_SHA=${{ github.sha }}
 
       - name: Create SBOM
-        uses: digitalservicebund/github-actions/create-sbom@c6b78c632c4b017802d3e3ce9706a43b9380f804
+        uses: digitalservicebund/create-sbom@095884614dac5ea922dfcb09cce2e22f3d6391a3 # v1.1.0
         with:
           image_name: ${{ env.IMAGE_NAME }}:${{ github.sha }}
 
@@ -135,7 +135,7 @@ jobs:
       security-events: write
     steps:
       - name: validate github workflow files to have pinned versions
-        uses: digitalservicebund/github-actions/github-actions-linter@c6b78c632c4b017802d3e3ce9706a43b9380f804 # v0.1.10
+        uses: digitalservicebund/github-actions-linter@16aee7d3ea804d707e9faf6ab3f049ef560dded7 # v0.1.11
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # v0.18.0

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: validate github workflow files to have pinned versions
-        uses: digitalservicebund/github-actions/github-actions-linter@c6b78c632c4b017802d3e3ce9706a43b9380f804 # v0.1.10
+        uses: digitalservicebund/github-actions-linter@16aee7d3ea804d707e9faf6ab3f049ef560dded7 # v0.1.11
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # v0.18.0

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: validate github workflow files to have pinned versions
-        uses: digitalservicebund/github-actions-linter@16aee7d3ea804d707e9faf6ab3f049ef560dded7 # v0.1.11
+        uses: digitalservicebund/github-actions-linter@dccac3ada437947aada4bc901daff08ceb87c3f1 # v0.1.11
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@062f2592684a31eb3aa050cc61e7ca1451cecd3d # v0.18.0


### PR DESCRIPTION
As mentioned [here](https://digitalservicebund.slack.com/archives/C03M9TZTDK8/p1710341286056739), we have to split our internal GitHub actions repo. This PR update your CI configuration to point to the new repositories. Please, review and merge this PR. Don't hesitate to contact the Platform team if you run into any issue.