### PR TITLE
Reuse scan workflow in pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -124,38 +124,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   vulnerability-scan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: validate github workflow files to have pinned versions
-        uses: digitalservicebund/github-actions-linter@dccac3ada437947aada4bc901daff08ceb87c3f1 # v0.1.11
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b2933f565dbc598b29947660e66259e3c7bc8561 # v0.20.0
-        env:
-          TRIVY_USERNAME: ${{ github.actor }}
-          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          scan-type: "fs"
-          skip-dirs: "node_modules" # See https://github.com/aquasecurity/trivy/issues/1283
-          format: "sarif"
-          output: "trivy-results.sarif"
-          severity: "CRITICAL,HIGH"
-          exit-code: "1" # Fail the build!
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@b7cec7526559c32f1616476ff32d17ba4c59b2d6 # v3.25.5
-        if: always() # Bypass non-zero exit code..
-        with:
-          sarif_file: "trivy-results.sarif"
-
-      - name: Send status to Slack
-        uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
-        if: ${{ failure() }}
-        with:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    uses: ./.github/workflows/scan.yml
 
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -125,6 +125,7 @@ jobs:
 
   vulnerability-scan:
     uses: ./.github/workflows/scan.yml
+    secrets: inherit
 
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -5,6 +5,7 @@ on:
     - cron: "0 6 * * *" # Every day at 8am
   # Allow to run this workflow manually
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   vulnerability-scan:
@@ -14,8 +15,12 @@ jobs:
       packages: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
-      - name: validate github workflow files to have pinned versions
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate github workflow files to have pinned versions
         uses: digitalservicebund/github-actions-linter@dccac3ada437947aada4bc901daff08ceb87c3f1 # v0.1.11
 
       - name: Run Trivy vulnerability scanner
@@ -30,11 +35,13 @@ jobs:
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
           exit-code: "1" # Fail the build!
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@b7cec7526559c32f1616476ff32d17ba4c59b2d6 # v3.25.5
         if: always() # Bypass non-zero exit code..
         with:
           sarif_file: "trivy-results.sarif"
+
       - name: Send status to Slack
         uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
         if: ${{ failure() }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -44,6 +44,6 @@ jobs:
 
       - name: Send status to Slack
         uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
-        if: ${{ failure() }}
+        # if: ${{ failure() }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -44,6 +44,6 @@ jobs:
 
       - name: Send status to Slack
         uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
-        # if: ${{ failure() }}
+        if: ${{ failure() }}
         with:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Reuse the workflow in `scan.yml` inside of the pipeline instead of having basically the same workflow twice.

closes #112 