### PR TITLE
fix(Docker): updating format to avoid LegacyKeyValueFormat warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci
 # Download and install the dependencies for running the app
 FROM node:20-alpine AS production-dependencies
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 WORKDIR /src
 COPY package*.json ./
 RUN npm ci


### PR DESCRIPTION
Hi,

I noticed a warning that occurs while running the `Docker build` command. That's an easy one to fix 😃 

<img width="863" alt="image" src="https://github.com/user-attachments/assets/1cd69eb9-1749-45bb-aac1-1ddb9ec22c8f">

Best regards