### PR TITLE
Cache playwright dependencies

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -59,6 +59,7 @@ jobs:
           restore-keys: ${{ runner.os }}-playwright-
 
       - name: Install E2E & A11y test dependencies
+        if: steps.cache-playwright-deps.outputs.cache-hit != 'true'
         run: |
           npx --yes playwright install --with-deps
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Cache Playwright dependencies
+        id: cache-playwright-deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-playwright-
+
       - name: Install E2E & A11y test dependencies
         run: |
           npx --yes playwright install --with-deps

--- a/.talismanrc
+++ b/.talismanrc
@@ -7,6 +7,8 @@ fileignoreconfig:
     checksum: 446eff0044854604c36e380d186aab48077af382668430ad518ef49b37d4fa02
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
+  - filename: .github/workflows/pipeline.yml
+    checksum: 738eefbfe8e0fc414a902de63a43600f8ce2d656ee9e33c1e4394726826ea96e
 version: ""
 scopeconfig:
   - scope: node


### PR DESCRIPTION
e2e test dependencies are installed each pipeline run, which takes ~40-60 seconds.

This PR introduces a change that caches these dependencies and reuses the cache in future builds if none of the dependencies have changed.

It takes ~10 seconds to restore the cache, so it reduces build times by ~30-50 seconds.