### PR TITLE
Cache docker image

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -88,6 +88,7 @@ jobs:
           path: tests/a11y/playwright-report
 
       - name: Cache Docker image
+        id: cache-docker-image
         uses: actions/cache@v4
         with:
           path: |
@@ -97,6 +98,7 @@ jobs:
             ${{ runner.os }}-docker-
 
       - name: Build and cache image from Dockerfile
+        if: steps.cache-docker-image.outputs.cache-hit != 'true'
         run: |
           mkdir -p /tmp/.docker-cache/${{ env.IMAGE_NAME }}
           docker build -t ${{ env.IMAGE_NAME }}:${{ github.sha }} . --build-arg COMMIT_SHA=${{ github.sha }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -169,8 +169,6 @@ jobs:
           path: |
             /tmp/.docker-cache
           key: ${{ runner.os }}-docker-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-docker-
 
       - name: Load cached Docker image
         id: load-docker-image

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -178,17 +178,17 @@ jobs:
           IMAGE_PATH="/tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar"
 
           if docker load -i $IMAGE_PATH; then
-            echo "cache-hit=true" >> $GITHUB_ENV
-            echo "::set-output name=cache-hit::true"
+            echo "docker-image-load-successful=true" >> $GITHUB_ENV
+            echo "::set-output name=docker-image-load-successful::true"
             echo "Docker image loaded from cache: $IMAGE_PATH"
           else
-            echo "cache-hit=false" >> $GITHUB_ENV
-            echo "::set-output name=cache-hit::false"
+            echo "docker-image-load-successful=false" >> $GITHUB_ENV
+            echo "::set-output name=docker-image-load-successful::false"
             echo "Docker image not found in cache: $IMAGE_PATH"
           fi
 
       - name: Build image from Dockerfile in case no cached image was found
-        if: steps.load-docker-image.outputs.cache-hit != 'true'
+        if: steps.load-docker-image.outputs.docker-image-load-successful != 'true'
         run: |
           docker build -t ${{ env.IMAGE_NAME }}:${{ github.sha }} . --build-arg COMMIT_SHA=${{ github.sha }}
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -95,14 +95,14 @@ jobs:
           key: ${{ runner.os }}-docker-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-docker-
-  
+
       - name: Build and cache image from Dockerfile
         run: |
           mkdir -p /tmp/.docker-cache/${{ env.IMAGE_NAME }}
           docker build -t ${{ env.IMAGE_NAME }}:${{ github.sha }} . --build-arg COMMIT_SHA=${{ github.sha }}
           docker save ${{ env.IMAGE_NAME }}:${{ github.sha }} -o /tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar
           echo "Docker image saved to: /tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar"
-  
+
       - name: Send failure to Slack
         uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
         if: ${{ failure() }}
@@ -175,8 +175,6 @@ jobs:
       - name: Load cached Docker image
         id: load-docker-image
         run: |
-          echo "IMAGE_NAME=${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
-          echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
           IMAGE_PATH="/tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar"
 
           if docker load -i $IMAGE_PATH; then

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -87,10 +87,22 @@ jobs:
           name: playwright-a11y-test-results
           path: tests/a11y/playwright-report
 
-      - name: Build an image from Dockerfile
+      - name: Cache Docker image
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/.docker-cache
+          key: ${{ runner.os }}-docker-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-docker-
+  
+      - name: Build and cache image from Dockerfile
         run: |
+          mkdir -p /tmp/.docker-cache/${{ env.IMAGE_NAME }}
           docker build -t ${{ env.IMAGE_NAME }}:${{ github.sha }} . --build-arg COMMIT_SHA=${{ github.sha }}
-
+          docker save ${{ env.IMAGE_NAME }}:${{ github.sha }} -o /tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar
+          echo "Docker image saved to: /tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar"
+  
       - name: Send failure to Slack
         uses: digitalservicebund/notify-on-failure-gha@814d0c4b2ad6a3443e89c991f8657b10126510bf # v1.5.0
         if: ${{ failure() }}
@@ -151,7 +163,34 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build image from Dockerfile
+      - name: Restore Docker image cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/.docker-cache
+          key: ${{ runner.os }}-docker-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-docker-
+
+      - name: Load cached Docker image
+        id: load-docker-image
+        run: |
+          echo "IMAGE_NAME=${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
+          echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
+          IMAGE_PATH="/tmp/.docker-cache/${{ env.IMAGE_NAME }}_${{ github.sha }}.tar"
+
+          if docker load -i $IMAGE_PATH; then
+            echo "cache-hit=true" >> $GITHUB_ENV
+            echo "::set-output name=cache-hit::true"
+            echo "Docker image loaded from cache: $IMAGE_PATH"
+          else
+            echo "cache-hit=false" >> $GITHUB_ENV
+            echo "::set-output name=cache-hit::false"
+            echo "Docker image not found in cache: $IMAGE_PATH"
+          fi
+
+      - name: Build image from Dockerfile in case no cached image was found
+        if: steps.load-docker-image.outputs.cache-hit != 'true'
         run: |
           docker build -t ${{ env.IMAGE_NAME }}:${{ github.sha }} . --build-arg COMMIT_SHA=${{ github.sha }}
 

--- a/.talismanrc
+++ b/.talismanrc
@@ -8,7 +8,7 @@ fileignoreconfig:
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/pipeline.yml
-    checksum: 5993769320cce3a8d0f71c883e6c542bc0122e0400d63b578b52e12b18d21d89
+    checksum: 82a641bb721bf6558001375793b3925fb81708520bb4c34c52779a1e2c4859a6
 version: ""
 scopeconfig:
   - scope: node

--- a/.talismanrc
+++ b/.talismanrc
@@ -8,7 +8,7 @@ fileignoreconfig:
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/pipeline.yml
-    checksum: 738eefbfe8e0fc414a902de63a43600f8ce2d656ee9e33c1e4394726826ea96e
+    checksum: ffed32060147da12c4f316ad65d29f204fcfdbdaf09ad0ed40dc246dd7ea703f
 version: ""
 scopeconfig:
   - scope: node

--- a/.talismanrc
+++ b/.talismanrc
@@ -8,7 +8,7 @@ fileignoreconfig:
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/pipeline.yml
-    checksum: ffed32060147da12c4f316ad65d29f204fcfdbdaf09ad0ed40dc246dd7ea703f
+    checksum: f75052d249ccf7b148af43738b1f23344fa8de1908c51373b225b2471ea7f30a
 version: ""
 scopeconfig:
   - scope: node

--- a/.talismanrc
+++ b/.talismanrc
@@ -8,7 +8,7 @@ fileignoreconfig:
   - filename: SECURITY.md
     checksum: b1743150cdd537be3a66f5308f887d130f0f320ab21628b63713808090a84e3f
   - filename: .github/workflows/pipeline.yml
-    checksum: f75052d249ccf7b148af43738b1f23344fa8de1908c51373b225b2471ea7f30a
+    checksum: 5993769320cce3a8d0f71c883e6c542bc0122e0400d63b578b52e12b18d21d89
 version: ""
 scopeconfig:
   - scope: node


### PR DESCRIPTION
The build pipeline currently includes these steps:

1. **Build** the docker image
2. **Build** and publish the docker image

This PR implements caching of the docker image, so that we don't have to build the same image twice. It changes the steps to the following:

1. **Build** and cache the docker image
1. Publish the cached docker image

This saves the time of rebuilding the image, which should save around 40 seconds with a small project, potentially more time with a larger project